### PR TITLE
Conditionally rename main to mosh_main for building under NaCl.

### DIFF
--- a/src/frontend/mosh-client.cc
+++ b/src/frontend/mosh-client.cc
@@ -93,7 +93,11 @@ void print_colorcount( void )
   printf( "%d\n", color_val );
 }
 
+#ifdef NACL
+int mosh_main( int argc, char *argv[] )
+#else
 int main( int argc, char *argv[] )
+#endif
 {
   /* For security, make sure we don't dump core */
   Crypto::disable_dumping_core();


### PR DESCRIPTION
This is the one and only patch I have in Mosh for Chrome to be able to use Mosh as a library in my NaCl wrapper. It'd be great to have it upstream so I don't have to worry about it anymore.