### PR TITLE
bash completion: Support ~/.ssh/config aliases

### DIFF
--- a/conf/bash_completion.d/mosh
+++ b/conf/bash_completion.d/mosh
@@ -1,1 +1,6 @@
-complete -F _known_hosts mosh
+_mosh ()
+{
+    COMPREPLY=()
+    _known_hosts_real -a -- "$(_get_cword)"
+} &&
+complete -F _mosh mosh


### PR DESCRIPTION
`_known_hosts` does not complete aliases defined in ~/.ssh/config by default, but it takes an `-a` option to do so.