### PR TITLE
allow/prefer a system OpenSSL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -243,7 +243,8 @@ AC_CHECK_FUNCS([m4_normalize([
 
 AC_SEARCH_LIBS([clock_gettime], [rt], [AC_DEFINE([HAVE_CLOCK_GETTIME], [1], [Define if clock_gettime is available.])])
 
-PKG_CHECK_MODULES([OPENSSL], [openssl])
+# Prefer system libcrypto to ports/packages OpenSSL.
+AC_CHECK_LIB([crypto], [AES_encrypt], , [PKG_CHECK_MODULES([OPENSSL], [openssl])])
 
 # Start by trying to find the needed tinfo parts by pkg-config
 PKG_CHECK_MODULES([TINFO], [tinfo],

--- a/configure.ac
+++ b/configure.ac
@@ -243,8 +243,21 @@ AC_CHECK_FUNCS([m4_normalize([
 
 AC_SEARCH_LIBS([clock_gettime], [rt], [AC_DEFINE([HAVE_CLOCK_GETTIME], [1], [Define if clock_gettime is available.])])
 
-# Prefer system libcrypto to ports/packages OpenSSL.
-AC_CHECK_LIB([crypto], [AES_encrypt], , [PKG_CHECK_MODULES([OPENSSL], [openssl])])
+# Support both OpenSSL from a package, for Linux, and libcrypto, for *BSDs and other OSes that bundle OpenSSL.
+# --with-openssl:  look for OpenSSL package, fail if not found
+# --with-openssl=check [default]: look for OpenSSL package, fall back to -lcrypto
+# --without-openssl: only look for -lcrypto
+AC_ARG_WITH([openssl],
+  [AS_HELP_STRING([--with-openssl], [use openssl package for AES @<:@check@:>@])]
+  [AS_HELP_STRING([--without-openssl], [use system libcrypto for AES])],
+  [with_openssl="$withval"],
+  [with_openssl="check"])
+AS_IF([test x"$with_openssl" != xno],
+  [PKG_CHECK_MODULES([OPENSSL], [openssl],,
+    [AS_IF([test x"$with_openssl" = xcheck],
+      [AC_CHECK_LIB([crypto], [AES_encrypt])],
+      [AC_MSG_ERROR([--with-openssl was given but no openssl package is available.])])])],
+  [AC_CHECK_LIB([crypto], [AES_encrypt])])
 
 # Start by trying to find the needed tinfo parts by pkg-config
 PKG_CHECK_MODULES([TINFO], [tinfo],

--- a/src/examples/parse.cc
+++ b/src/examples/parse.cc
@@ -50,6 +50,8 @@
 #include <pty.h>
 #elif HAVE_UTIL_H
 #include <util.h>
+#elif HAVE_LIBUTIL_H
+#include <libutil.h>
 #endif
 
 #include "parser.h"

--- a/src/examples/termemu.cc
+++ b/src/examples/termemu.cc
@@ -56,6 +56,8 @@
 #include <pty.h>
 #elif HAVE_UTIL_H
 #include <util.h>
+#elif HAVE_LIBUTIL_H
+#include <libutil.h>
 #endif
 
 #include "parser.h"

--- a/src/frontend/stmclient.cc
+++ b/src/frontend/stmclient.cc
@@ -172,12 +172,12 @@ void STMClient::init( void )
   if ( escape_key > 0 ) {
     char escape_pass_name_buf[16];
     char escape_key_name_buf[16];
-    sprintf(escape_pass_name_buf, "\"%c\"", escape_pass_key);
+    snprintf(escape_pass_name_buf, sizeof escape_pass_name_buf, "\"%c\"", escape_pass_key);
     if (escape_key < 32) {
-      sprintf(escape_key_name_buf, "Ctrl-%c", escape_pass_key);
+      snprintf(escape_key_name_buf, sizeof escape_key_name_buf, "Ctrl-%c", escape_pass_key);
       escape_requires_lf = false;
     } else {
-      sprintf(escape_key_name_buf, "\"%c\"", escape_key);
+      snprintf(escape_key_name_buf, sizeof escape_key_name_buf, "\"%c\"", escape_key);
       escape_requires_lf = true;
     }
     string tmp;

--- a/src/util/pty_compat.cc
+++ b/src/util/pty_compat.cc
@@ -62,7 +62,7 @@ pid_t my_forkpty( int *amaster, char *name,
 
   master = open( PTY_DEVICE, O_RDWR | O_NOCTTY );
   if ( master < 0 ) {
-    perror( "open("PTY_DEVICE")" );
+    perror( "open(" PTY_DEVICE ")" );
     return -1;
   }
 


### PR DESCRIPTION
FreeBSD (and the other BSDs) bundle OpenSSL into the base system.  They may not have it installed as a package.  Attempting to configure Mosh on such a system will fail.  This builds fine on the Linux systems I have available but it might go wrong someplace else.

There are other portability fixes in the performance branch which I will be pushing shortly, I didn't fully disentangle all my commits.
