### PR TITLE
scripts/mosh: Allow IO::Socket::INET6 as an alternative to IO::Socket::IP

### DIFF
--- a/man/mosh.1
+++ b/man/mosh.1
@@ -123,7 +123,8 @@ Synonym for \-\-predict=never
 .TP
 .B --family=\fIFAMILY\fP
 Force the use of a particular address family, which defaults to `inet'
-(IPv4), and can also be `inet6' (IPv6; requires IO::Socket::IP).
+(IPv4), and can also be `inet6' (IPv6; requires IO::Socket::IP or
+IO::Socket::INET6).
 
 .TP
 .B -4

--- a/scripts/mosh
+++ b/scripts/mosh
@@ -174,7 +174,10 @@ if ( not defined $bind_ip or $bind_ip =~ m{^ssh$}i ) {
 
 if ( defined $fake_proxy ) {
   use Errno qw(EINTR);
-  BEGIN { eval { require IO::Socket::IP; IO::Socket::IP->import('-register'); }; }
+  BEGIN {
+    eval { require IO::Socket::IP; IO::Socket::IP->import('-register'); 1 } or
+      eval { require IO::Socket::INET6 };
+  }
   use POSIX qw(_exit);
 
   my ( $host, $port ) = @ARGV;


### PR DESCRIPTION
Some systems have IO::Socket::INET6 preinstalled, so we might as well accept either.