### PR TITLE
ocb: fix gcc4.8 compiling problem with __ARM_NEON__

### DIFF
--- a/src/crypto/ocb.cc
+++ b/src/crypto/ocb.cc
@@ -260,7 +260,7 @@
 	}
 	static inline block double_block(block b)
 	{
-		const block mask = {135,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1};
+		const block mask = {-121,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1};
 		block tmp = vshrq_n_s8(b,7);
 		tmp = vandq_s8(tmp, mask);
 		tmp = vextq_s8(tmp, tmp, 1);  /* Rotate high byte to end */


### PR DESCRIPTION
Fixes following problem when compiling mosh with gcc4.8 and
__ARM_NEON__ defined by proper casting.

ocb.cc: In function 'block double_block(block)':
ocb.cc:263:56: error: narrowing conversion of '135' from
'int' to '__builtin_neon_qi' inside { } is ill-formed in
C++11 [-Werror=narrowing]