### PR TITLE
Use IO::Socket::IP to prefer v6, and to not require -6 for v6-only hosts

### DIFF
--- a/scripts/mosh
+++ b/scripts/mosh
@@ -35,7 +35,7 @@ my $MOSH_VERSION = '1.2.4a';
 use warnings;
 use strict;
 use Getopt::Long;
-use IO::Socket;
+use IO::Socket::IP;
 
 $|=1;
 
@@ -46,7 +46,7 @@ my $predict = undef;
 
 my $bind_ip = undef;
 
-my $family = 'inet';
+my $family = "unspec"; # currently unused unless overridden
 my $port_request = undef;
 
 my $ssh = 'ssh';
@@ -180,13 +180,19 @@ if ( defined $fake_proxy ) {
   my ( $host, $port ) = @ARGV;
 
   # Resolve hostname and connect
-  my $afstr = 'AF_' . uc( $family );
-  my $af = eval { IO::Socket->$afstr } or die "$0: Invalid family $family\n";
-  my $sock = IO::Socket->new( Domain => $af,
-			      Family => $af,
-			      PeerHost => $host,
-			      PeerPort => $port,
-			      Proto => "tcp" )
+  my %hints = (socktype => SOCK_STREAM);
+
+  my $af_family = AF_UNSPEC;
+  if ($family eq "inet6") {
+    $af_family = AF_INET6;
+  } elsif ($family eq "inet") {
+    $af_family = AF_INET;
+  }
+
+  my $sock = IO::Socket::IP->new(Family => $af_family,
+				PeerHost => $host,
+				PeerPort => $port,
+				Proto => "tcp")
     or die "$0: Could not connect to $host: $@\n";
 
   print STDERR "MOSH IP ", $sock->peerhost, "\n";

--- a/scripts/mosh
+++ b/scripts/mosh
@@ -180,8 +180,6 @@ if ( defined $fake_proxy ) {
   my ( $host, $port ) = @ARGV;
 
   # Resolve hostname and connect
-  my %hints = (socktype => SOCK_STREAM);
-
   my $af_family = AF_UNSPEC;
   if ($family eq "inet6") {
     $af_family = AF_INET6;


### PR DESCRIPTION
If I'm using a host with v4 and v6, I'd like mosh to use v6 by default.

If I'm using a host with only v6, I'd like to use mosh without forcing -6.

This is a short change to /scripts/mosh to use IO::Socket::IP to achieve precisely that. -4/-6/--family semantics should be unchanged.