### PR TITLE
1.2.4.95rc1 pre-release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,41 @@
+2015-06-?? Keith Winstein <mosh-devel@mit.edu>
+
+       * Version 1.2.5 released.
+
+       * New features:
+               * Bind to a specific IP address with --bind-server. (Philipp Haselwarter)
+               * MOSH_ESCAPE_KEY configures escape character.  (Timo J. Rinne)
+               * Support non-roaming IPv6. (Anders Kaseorg)
+               * Implement XTerm mouse mode. (Barosl LEE, Andrew Chin, Louis Kruger)
+               * Report Git revision along with version if available.  (John Hood)
+
+       * Platform support:
+               * Add pselect() emulation. (Jérémie Courrèges-Anglas)
+               * OpenBSD, OS X: Fix be64toh-related issues. (Jérémie Courrèges-Anglas)
+               * ARM Neon: fix gcc4.8 compiling problem(Pasi Sjöholm)
+               * NaCl: Conditionally rename main to mosh_main. (Richard Woodbury)
+               * FreeBSD: Token pasting, forkpty(), ARM fixes. (John Hood)
+               * AIX: Implement CTTY grabbing when TIOCSCTTY is missing
+                 (Anton Lundin)
+
+       * Bug fixes:
+               * Automake/autoconf workarounds.  (Anders Kaseorg)
+               * mosh-server: Allow startup without PTY.  (Keith Winstein)
+               * network.cc: Properly close old fd on Socket assignment operator.
+                 (Thanks to Igor Bukanov)
+               * mosh-server:  Allow startup with zero-window-size PTY.
+                 (Igor Bukanov)
+               * AddrInfo: Fix error message generation when node == NULL
+                 (Anders Kaseorg)
+               * Timestamp: Prevent integer overflow on Darwin PPC 32-bit
+                 (Anders Kaseorg)
+               * scripts/mosh: Fix hang when remote closes the connection
+                 (Anders Kaseorg)
+               * Fix issues with parsing of 256-color SGR sequences.
+                 (John Hood)
+               * Numerous code hygiene, Coverity, and Clang static analyzer
+                 fixes.  (Anders Kaseorg, Geoffrey Thomas, John Hood)
+
 2013-03-27 Keith Winstein <mosh-devel@mit.edu>
 
 	* Version 1.2.4 released.

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.61])
-AC_INIT([mosh], [1.2.4a], [mosh-devel@mit.edu])
+AC_INIT([mosh], [1.2.4.95rc1], [mosh-devel@mit.edu])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CONFIG_SRCDIR([src/frontend/mosh-client.cc])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,43 @@
+mosh (1.2.4.95rc1-1) unstable; urgency=low
+
+  * Version 1.2.5 release candidate.
+
+  * New features:
+    * Bind to a specific IP address with --bind-server. (Philipp Haselwarter)
+    * MOSH_ESCAPE_KEY configures escape character.  (Timo J. Rinne)
+    * Support non-roaming IPv6. (Anders Kaseorg)
+    * Implement XTerm mouse mode. (Barosl LEE, Andrew Chin, Louis Kruger)
+    * Report Git revision along with version if available.  (John Hood)
+
+  * Platform support:
+    * Add pselect() emulation. (Jérémie Courrèges-Anglas)
+    * OpenBSD, OS X: Fix be64toh-related issues. (Jérémie Courrèges-Anglas)
+    * ARM Neon: fix gcc4.8 compiling problem(Pasi Sjöholm)
+    * NaCl: Conditionally rename main to mosh_main. (Richard Woodbury)
+    * FreeBSD: Token pasting, forkpty(), ARM fixes. (John Hood)
+    * AIX: Implement CTTY grabbing when TIOCSCTTY is missing
+      (Anton Lundin)
+
+  * Bug fixes:
+    * Automake/autoconf workarounds.  (Anders Kaseorg)
+    * mosh-server: Allow startup without PTY.  (Keith Winstein)
+    * network.cc: Properly close old fd on Socket assignment operator.
+      (Thanks to Igor Bukanov)
+    * mosh-server:  Allow startup with zero-window-size PTY.
+      (Igor Bukanov)
+    * AddrInfo: Fix error message generation when node == NULL
+      (Anders Kaseorg)
+    * Timestamp: Prevent integer overflow on Darwin PPC 32-bit
+      (Anders Kaseorg)
+    * scripts/mosh: Fix hang when remote closes the connection
+      (Anders Kaseorg)
+    * Fix issues with parsing of 256-color SGR sequences.
+      (John Hood)
+    * Numerous code hygiene, Coverity, and Clang static analyzer
+      fixes.  (Anders Kaseorg, Geoffrey Thomas, John Hood)
+
+ -- Keith Winstein <keithw@mit.edu>  Mon, 08 Jun 2015 22:45:00 -0400
+
 mosh (1.2.4a-1) unstable; urgency=low
 
   * Eliminate redundant ocb.cc test (fixes build warning on ARM/MIPS/s390)

--- a/fedora/mosh.spec
+++ b/fedora/mosh.spec
@@ -1,5 +1,5 @@
 Name:		mosh
-Version:	1.2.4
+Version:	1.2.4.95rc1
 Release:	1%{?dist}
 Summary:	Mobile shell that supports roaming and intelligent local echo
 
@@ -16,6 +16,7 @@ BuildRequires:	ncurses-devel
 BuildRequires:	openssl-devel
 Requires:	openssh-clients
 Requires:	openssl
+Requires:	perl-IO-Socket-IP
 
 %description
 Mosh is a remote terminal application that supports:
@@ -51,6 +52,9 @@ make install DESTDIR=$RPM_BUILD_ROOT
 
 
 %changelog
+* Mon Jun 08 2015 John Hood <cgull@glup.org> - 1.2.4.95rc1-1
+- Update to mosh 1.2.4.95rc1
+
 * Wed Mar 27 2013 Alexander Chernyakhovsky <achernya@mit.edu> - 1.2.4-1
 - Update to mosh 1.2.4
 


### PR DESCRIPTION
So here's build + packaging for 1.2.4.95rc1.  @keithw, would you review this?
* Ubuntu/Debian package build and install works
* Fedora build and install works
* Mac OS X package is still broken
* I'm talking to the FreeBSD ports maintainer, he seems happy to pick up the new version once we get to it

As for pushing the new packaging to Debian/Canonical and to Fedora/Redhat, who does that?  @keithw, me, Yoda?