### PR TITLE
Improve Debian bash-completion support (see #628)

### DIFF
--- a/conf/Makefile.am
+++ b/conf/Makefile.am
@@ -1,3 +1,5 @@
+completionsdir = @completions@
+dist_completions_DATA =
 nobase_dist_sysconf_DATA =
 
 if INSTALL_UFW
@@ -5,5 +7,5 @@ if INSTALL_UFW
 endif
 
 if INSTALL_COMPLETION
-  nobase_dist_sysconf_DATA += bash_completion.d/mosh
+  dist_completions_DATA += bash-completion/completions/mosh
 endif

--- a/conf/bash-completion/completions/mosh
+++ b/conf/bash-completion/completions/mosh
@@ -1,0 +1,9 @@
+_mosh () {
+    local cur prev
+
+    _init_completion || return
+
+    _known_hosts_real -a "$cur"
+}
+
+complete -F _mosh mosh

--- a/conf/bash_completion.d/mosh
+++ b/conf/bash_completion.d/mosh
@@ -1,1 +1,0 @@
-complete -F _known_hosts mosh

--- a/configure.ac
+++ b/configure.ac
@@ -369,6 +369,13 @@ AC_CHECK_DECL([IUTF8],
 # Checks for protobuf
 PKG_CHECK_MODULES([protobuf], [protobuf])
 
+# Bash completion needs to ask where it goes if >= 2.0 is installed.
+AS_IF([test "$install_completion" != no],
+  [PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
+     [completions="`pkg-config --variable=completionsdir bash-completion`"],
+     [completions="${sysconfdir}/bash-completion.d"])
+   AC_SUBST([completions])])
+
 AC_CONFIG_FILES([
   Makefile
   src/Makefile

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: mosh
 Section: net
 Priority: optional
 Maintainer: Keith Winstein <keithw@mit.edu>
-Build-Depends: debhelper (>= 7.0.50), autotools-dev, protobuf-compiler, libprotobuf-dev, dh-autoreconf, pkg-config, libutempter-dev, zlib1g-dev, libncurses5-dev, libssl-dev
+Build-Depends: debhelper (>= 7.0.50), autotools-dev, protobuf-compiler, libprotobuf-dev, dh-autoreconf, pkg-config, libutempter-dev, zlib1g-dev, libncurses5-dev, libssl-dev, bash-completion
 Standards-Version: 3.9.6.1
 Homepage: http://mosh.mit.edu
 Vcs-Git: git://github.com/keithw/mosh.git
@@ -10,6 +10,7 @@ Vcs-Browser: https://github.com/keithw/mosh
 
 Package: mosh
 Architecture: any
+Pre-Depends: dpkg (>= 1.15.7.2)
 Depends: ${shlibs:Depends}, ${misc:Depends}, openssh-client
 Recommends: libio-socket-ip-perl
 Description: Mobile shell that supports roaming and intelligent local echo

--- a/debian/mosh.maintscript
+++ b/debian/mosh.maintscript
@@ -1,0 +1,1 @@
+rm_conffile /etc/bash_completion.d/mosh 1.2.5~ -- "$@"


### PR DESCRIPTION
* Autoconf queries pkgconf for bash-completion dir-- resolves
  lintian's `package-install-into-obsolete-dir` diagnostic
* Use improved completion snippet from
  <https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=782169>
* Remove old /etc/bash_completion.d/mosh "conffile" with
  dh-maintscript + dpkg-maintscript-helper

Closes #628.

Signed-off-by: John Hood <cgull@glup.org>