### PR TITLE
Remove system("locale") calls.

### DIFF
--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -313,7 +313,6 @@ int main( int argc, char *argv[] )
       fprintf( stderr, "mosh-server needs a UTF-8 native locale to run.\n\n" );
       fprintf( stderr, "Unfortunately, the local environment (%s) specifies\nthe character set \"%s\",\n\n", native_ctype.str().c_str(), native_charset.c_str() );
       fprintf( stderr, "The client-supplied environment (%s) specifies\nthe character set \"%s\".\n\n", client_ctype.str().c_str(), client_charset.c_str() );
-      int unused __attribute((unused)) = system( "locale" );
       exit( 1 );
     }
   }

--- a/src/frontend/stmclient.cc
+++ b/src/frontend/stmclient.cc
@@ -85,7 +85,6 @@ void STMClient::init( void )
 
     fprintf( stderr, "mosh-client needs a UTF-8 native locale to run.\n\n" );
     fprintf( stderr, "Unfortunately, the client's environment (%s) specifies\nthe character set \"%s\".\n\n", native_ctype.str().c_str(), native_charset.c_str() );
-    int unused __attribute((unused)) = system( "locale" );
     exit( 1 );
   }
 


### PR DESCRIPTION
The locale command is not available on many systems. As this variable
is unused and appears to have been written with the intent of
displaying the locale settings to the user, it's not really necessary.
As this breaks Mosh on a lot of systems, it's best to remove the calls.